### PR TITLE
Serialize objects with custom attributes

### DIFF
--- a/dict_model/__init__.py
+++ b/dict_model/__init__.py
@@ -11,7 +11,7 @@ from django.utils.functional import classproperty
 from . import deserializers, lookup, serializers
 from .query_sets import DictModelQuerySet
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 
 @dataclasses.dataclass

--- a/dict_model/__init__.py
+++ b/dict_model/__init__.py
@@ -309,9 +309,6 @@ class DictModel:
             pass
 
     def to_dict(self) -> dict:
-        if self.__class__.get_custom_attributes_of_child(self):
-            raise DictModel.CannotSerializeCustomAttributes(str(self))
-
         return {
             field: DictModel.serialize(getattr(self, field))
             for field in self.__class__.field_names

--- a/tests/test_dict_model.py
+++ b/tests/test_dict_model.py
@@ -279,11 +279,10 @@ def test_dict_model_to_dict(example_model):
     }
 
 
-def test_dict_model_to_dict_raises_error_with_custom_attributes(example_model):
+def test_dict_model_to_dict_ignores_custom_attributes(example_model):
     example = example_model(id=1, foo="bar")
     example.custom = lambda _: "this won't serialize!"
-    with pytest.raises(dict_model.DictModel.CannotSerializeCustomAttributes):
-        example.to_dict()
+    assert "custom" not in example.to_dict()
 
 
 def test_dict_model_from_json_file_identifies_model_and_initializes_data(


### PR DESCRIPTION
Ignore custom attributes when serializing objects, as opposed to raising an error.