### PR TITLE
Mimick Django object manager interface

### DIFF
--- a/dict_model/__init__.py
+++ b/dict_model/__init__.py
@@ -3,9 +3,9 @@ import functools
 import json
 import re
 import typing
+from copy import copy
 from datetime import datetime
 from pathlib import Path
-from copy import copy
 
 from django.utils.functional import classproperty
 
@@ -55,7 +55,6 @@ class DictModelObjectManager:
 
 @dataclasses.dataclass(kw_only=True)
 class DictModel:
-
     class AlreadyInitialized(Exception):
         pass
 

--- a/tests/test_dict_model.py
+++ b/tests/test_dict_model.py
@@ -543,9 +543,7 @@ def test_dict_model_objects_can_be_a_custom_object_manager():
 
         name: str
 
-        object_data = {
-            1: {"id": 1, "name": "monkey"}
-        }
+        object_data = {1: {"id": 1, "name": "monkey"}}
 
     CustomManagement.init()
     assert CustomManagement.objects.funky(1) == "get funky: monkey"

--- a/tests/test_dict_model.py
+++ b/tests/test_dict_model.py
@@ -539,22 +539,13 @@ def test_dict_model_objects_can_be_a_custom_object_manager():
 
     @dataclass
     class CustomManagement(dict_model.DictModel):
+        objects = CustomObjectManager()
+
         name: str
 
         object_data = {
             1: {"id": 1, "name": "monkey"}
         }
 
-        objects = CustomObjectManager
-
     CustomManagement.init()
     assert CustomManagement.objects.funky(1) == "get funky: monkey"
-
-
-def test_dict_model_objects_raises_error_if_model_has_not_been_initialized():
-    @dataclass
-    class PizzaSize(dict_model.DictModel):
-        name: str
-
-    with pytest.raises(AttributeError):
-        PizzaSize.objects


### PR DESCRIPTION
In a Django model, the object manager is defined as an _instance_ of a class:

```python3
class Foo(models.Model):
    ...
    objects = FooObjectManager()
```

Whereas in `dict-model`, the object manager class was assigned and then instantiated later:

```python3
class DictFoo(DictModel):
    ....
    objects = DictFooObjectManager
```

This PR brings the `dict-model` object manager pattern in line with Django, so that you define a custom object manager as an instantiated object (not a reference to the class you want to use to build the object):

```python3
class DictFoo(DictModel):
    ....
    objects = DictFooObjectManager()
```