### PR TITLE
TypeError: concatenate tuple (not "str") to tuple

### DIFF
--- a/dict_model/__init__.py
+++ b/dict_model/__init__.py
@@ -12,7 +12,7 @@ from django.utils.functional import classproperty
 from . import deserializers, lookup, serializers
 from .query_sets import DictModelQuerySet
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 
 @dataclasses.dataclass

--- a/dict_model/django.py
+++ b/dict_model/django.py
@@ -38,7 +38,7 @@ class DictModelField(models.IntegerField):
 
     @property
     def non_db_attrs(self):
-        return super().non_db_attrs + ("_dict_model_class")
+        return super().non_db_attrs + ("_dict_model_class",)
 
     def clean(self, value, model_instance):
         value = self.to_python(value).id


### PR DESCRIPTION
closes #7 

When I make a new Dict Model I get the error TypeError: concatenate tuple (not "str") to tuple. This should now be two tuples 

My Code that triggered the error 
```
@dataclass
class MetaPreviewType(DictModel):
    name: str
    cssClass: str
    faIcon: str

    object_data = {
        1: {"name": "Meta Icon", "cssClass": "meta-icon", "faIcon": "fa-grip-lines"},
        2: {"name": "Meta Inline", "cssClass": "meta-inline", "faIcon": "fa-language"},
        3: {"name": "Meta Card", "cssClass": "meta-card", "faIcon": "fa-clapperboard"},
        4: {"name": "Meta Layer", "cssClass": "meta-layer", "faIcon": "fa-layer-group"},
    }

```

Error Message 
```
    @property
    def non_db_attrs(self):
>       return super().non_db_attrs + ("_dict_model_class")
E       TypeError: can only concatenate tuple (not "str") to tuple

env/lib/python3.10/site-packages/dict_model/django.py:41: TypeError
```